### PR TITLE
 added callbacks to setMerchantId and setStripePublishableKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This plugin is a basic implementation of Stripe and Apple Pay with the purpose o
 ```sh
 cordova plugin add https://github.com/mtshare/cordova-plugin-applepay
 ```
+4. Add your **Stripe publishable key** and **merchant ID** to **config.xml**
+```
+<edit-config file="*-Info.plist" mode="merge" target="StripePublishableKey">
+	<string>pk_test_stripekey</string>
+</edit-config>
+<edit-config file="*-Info.plist" mode="merge" target="ApplePayMerchant">
+	<string>merchant.apple.test</string>
+</edit-config>
+```
 
 ## Supported Platforms
 
@@ -33,7 +42,7 @@ ApplePay.getAllowsApplePay(successCallback, errorCallback);
 
 #### ApplePay.setMerchantId
 
-Set your Apple-given merchant ID. This overrides the value obtained from **ApplePayMerchant** in **Info.plist**.
+Set your Apple-given merchant ID. This overrides the value obtained from **ApplePayMerchant** in **config.xml**.
 
 ```js
 ApplePay.setMerchantId('merchant.apple.test', successCallback, errorCallback);
@@ -41,7 +50,7 @@ ApplePay.setMerchantId('merchant.apple.test', successCallback, errorCallback);
 
 #### ApplePay.setStripePublishableKey
 
-Set your Stripe Publishable Key. This overrides the value obtained from **StripePublishableKey** in **Info.plist**.
+Set your Stripe Publishable Key. This overrides the value obtained from **StripePublishableKey** in **config.xml**.
 
 ```js
 ApplePay.setStripePublishableKey('pk_test_stripekey', successCallback, errorCallback);

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -27,6 +27,12 @@
     publishableKey = [command.arguments objectAtIndex:0];
     [Stripe setDefaultPublishableKey:publishableKey];
     
+    
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                messageAsString:[NSString stringWithFormat: @"set Stripe publishable key %@", publishableKey]];
+    [self.commandDelegate sendPluginResult:result
+                                callbackId:command.callbackId];
+    
 #ifdef DEBUG
     NSLog(@"ApplePay set Stripe publishable key %@", publishableKey);
 #endif
@@ -40,6 +46,11 @@
 - (void)setMerchantId:(CDVInvokedUrlCommand*)command
 {
     merchantId = [command.arguments objectAtIndex:0];
+    
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                messageAsString:[NSString stringWithFormat: @"set merchant id to %@", merchantId]];
+    [self.commandDelegate sendPluginResult:result
+                                callbackId:command.callbackId];
     
 #ifdef DEBUG
     NSLog(@"ApplePay set merchant id to %@", merchantId);

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -21,8 +21,8 @@ module.exports = {
      * Setting Stripe publishable key
      * @param {string} publishableKey  Stripe Publishable Key
      */
-    setStripePublishableKey: function (publishableKey) {
-        exec(null, null, 'ApplePay', 'setStripePublishableKey', [publishableKey]);
+    setStripePublishableKey: function (publishableKey, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'ApplePay', 'setStripePublishableKey', [publishableKey]);
     },
 
     
@@ -30,8 +30,8 @@ module.exports = {
      * Set Apple Marchant ID
      * @param {string} merchantId      Apple merchant ID
      */
-    setMerchantId: function (merchantId) {
-        exec(null, null, 'ApplePay', 'setMerchantId', [merchantId]);
+    setMerchantId: function (merchantId, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'ApplePay', 'setMerchantId', [merchantId]);
     },
 
 


### PR DESCRIPTION
- added success callback for `setMerchantId` which was documented but not implemented
- added success callback for `setStripePublishableKey` which was documented but not implemented
- added documentation for initialising merchant ID and Stripe publishable key in plist from config.xml