### PR TITLE
✨ feature/open-payment-setup Adds the openPaymentSetup method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This plugin is a basic implementation of Stripe and Apple Pay with the purpose o
 ```sh
 cordova plugin add https://github.com/mtshare/cordova-plugin-applepay
 ```
+4. Add your **Stripe publishable key** and **merchant ID** to **config.xml**
+```
+<edit-config file="*-Info.plist" mode="merge" target="StripePublishableKey">
+	<string>pk_test_stripekey</string>
+</edit-config>
+<edit-config file="*-Info.plist" mode="merge" target="ApplePayMerchant">
+	<string>merchant.apple.test</string>
+</edit-config>
+```
 
 ## Supported Platforms
 
@@ -33,7 +42,7 @@ ApplePay.getAllowsApplePay(successCallback, errorCallback);
 
 #### ApplePay.setMerchantId
 
-Set your Apple-given merchant ID. This overrides the value obtained from **ApplePayMerchant** in **Info.plist**.
+Set your Apple-given merchant ID. This overrides the value obtained from **ApplePayMerchant** in **config.xml**.
 
 ```js
 ApplePay.setMerchantId('merchant.apple.test', successCallback, errorCallback);
@@ -41,7 +50,7 @@ ApplePay.setMerchantId('merchant.apple.test', successCallback, errorCallback);
 
 #### ApplePay.setStripePublishableKey
 
-Set your Stripe Publishable Key. This overrides the value obtained from **StripePublishableKey** in **Info.plist**.
+Set your Stripe Publishable Key. This overrides the value obtained from **StripePublishableKey** in **config.xml**.
 
 ```js
 ApplePay.setStripePublishableKey('pk_test_stripekey', successCallback, errorCallback);

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cordova plugin add https://github.com/mtshare/cordova-plugin-applepay
 - ApplePay.getAllowsApplePay
 - ApplePay.setMerchantId
 - ApplePay.setStripePublishableKey
+- ApplePay.openPaymentSetup
 - ApplePay.getStripeToken
 
 #### ApplePay.getAllowsApplePay
@@ -54,6 +55,14 @@ Set your Stripe Publishable Key. This overrides the value obtained from **Stripe
 
 ```js
 ApplePay.setStripePublishableKey('pk_test_stripekey', successCallback, errorCallback);
+```
+
+#### ApplePay.openPaymentSetup
+
+Move the user to the interface for adding credit cards. This will open up the Wallet app on iPhone or to the Settings app on iPad. If the device does not support Apple Pay, this does nothing.
+
+```js
+ApplePay.openPaymentSetup();
 ```
 
 #### ApplePay.getStripeToken

--- a/src/ios/CDVApplePay.h
+++ b/src/ios/CDVApplePay.h
@@ -19,6 +19,12 @@
 
 
 /**
+ * Open payment setup
+ */
+-(void)openPaymentSetup:(CDVInvokedUrlCommand*)command;
+
+
+/**
  * Check if Apple Pay is available
  */
 - (void)getAllowsApplePay:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -59,6 +59,16 @@
 
 
 
+/**
+ * Open payment setup
+ */
+- (void)openPaymentSetup:(CDVInvokedUrlCommand*)command
+{
+    PKPassLibrary* lib = [[PKPassLibrary alloc] init];
+    [lib openPaymentSetup];
+}
+
+
 
 - (void)getAllowsApplePay:(CDVInvokedUrlCommand*)command
 {

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -27,6 +27,12 @@
     publishableKey = [command.arguments objectAtIndex:0];
     [Stripe setDefaultPublishableKey:publishableKey];
     
+    
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                messageAsString:[NSString stringWithFormat: @"set Stripe publishable key %@", publishableKey]];
+    [self.commandDelegate sendPluginResult:result
+                                callbackId:command.callbackId];
+    
 #ifdef DEBUG
     NSLog(@"ApplePay set Stripe publishable key %@", publishableKey);
 #endif
@@ -40,6 +46,11 @@
 - (void)setMerchantId:(CDVInvokedUrlCommand*)command
 {
     merchantId = [command.arguments objectAtIndex:0];
+    
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                messageAsString:[NSString stringWithFormat: @"set merchant id to %@", merchantId]];
+    [self.commandDelegate sendPluginResult:result
+                                callbackId:command.callbackId];
     
 #ifdef DEBUG
     NSLog(@"ApplePay set merchant id to %@", merchantId);

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -21,8 +21,8 @@ module.exports = {
      * Setting Stripe publishable key
      * @param {string} publishableKey  Stripe Publishable Key
      */
-    setStripePublishableKey: function (publishableKey) {
-        exec(null, null, 'ApplePay', 'setStripePublishableKey', [publishableKey]);
+    setStripePublishableKey: function (publishableKey, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'ApplePay', 'setStripePublishableKey', [publishableKey]);
     },
 
     
@@ -30,8 +30,8 @@ module.exports = {
      * Set Apple Marchant ID
      * @param {string} merchantId      Apple merchant ID
      */
-    setMerchantId: function (merchantId) {
-        exec(null, null, 'ApplePay', 'setMerchantId', [merchantId]);
+    setMerchantId: function (merchantId, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'ApplePay', 'setMerchantId', [merchantId]);
     },
 
 

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -36,6 +36,14 @@ module.exports = {
 
 
     /**
+     * Open payment setup
+     */
+    openPaymentSetup: function() {
+        exec(null, null, 'ApplePay', 'openPaymentSetup', []);
+    },
+
+
+    /**
      * Retrive Stripe token
      * @param  {object} infos
      * {


### PR DESCRIPTION
For when the device supports Apple Pay but has no configured cards, the "Set up Apple Pay" button must be displayed and be taken to the Wallet/Settings app and prompted to add a new credit/debit card.